### PR TITLE
Add create and activate endpoint

### DIFF
--- a/docs/api/old-v2.10.yaml
+++ b/docs/api/old-v2.10.yaml
@@ -79,7 +79,7 @@ paths:
     put:
       tags:
         - Service API
-      summary: create and activate service
+      summary: create, associate number and activate service
       operationId: addServiceAndActivate
       consumes:
         - application/json
@@ -2600,6 +2600,10 @@ definitions:
         enum:
           - TRUNKSIP
           - CLOUDCALLING
+      number:
+        type: string
+      activityNumber:
+        type: string
       serviceActivity:
         type: string
         enum:

--- a/docs/api/old-v2.10.yaml
+++ b/docs/api/old-v2.10.yaml
@@ -75,6 +75,44 @@ paths:
         - epic-ci:
             - all
       deprecated: false
+  "/private/auth/services/createandactivate":
+    put:
+      tags:
+        - Service API
+      summary: create and activate service
+      operationId: addServiceAndActivate
+      consumes:
+        - application/json
+      produces:
+        - "*/*"
+      parameters:
+        - in: body
+          name: addServiceRequest
+          description: addServiceRequest
+          required: true
+          schema:
+            originalRef: AddServiceRequestDTO
+            "$ref": "#/definitions/AddServiceRequestDTO"
+      responses:
+        '200':
+          description: OK
+          schema:
+            originalRef: ServiceDTO
+            "$ref": "#/definitions/ServiceDTO"
+        '201':
+          description: Service created and activated
+          schema:
+            originalRef: ServiceDTO
+            "$ref": "#/definitions/ServiceDTO"
+        '500':
+          description: Internal error
+      security:
+        - OAuth2: []
+        - monaco-telecom-dev:
+            - all
+        - epic-ci:
+            - all
+      deprecated: false
     post:
       tags:
         - ActivationCode API

--- a/docs/api/stable-v2.21.yaml
+++ b/docs/api/stable-v2.21.yaml
@@ -893,6 +893,40 @@ paths:
           description: Not Found
       security:
         - OAuth2: [ ]
+  /private/auth/services/createandactivate:
+    put:
+      tags:
+        - Service API
+      summary: create and activate service
+      operationId: addServiceAndActivate
+      consumes:
+        - application/json
+      produces:
+        - '*/*'
+      parameters:
+        - in: body
+          name: addServiceRequest
+          description: addServiceRequest
+          required: true
+          schema:
+            $ref: '#/definitions/AddServiceRequestDTO'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/ServiceDTO'
+        '201':
+          description: Service created and activated
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: Not Found
+        '500':
+          description: Internal error
+      security:
+        - OAuth2: [ ]
     put:
       tags:
         - Service API

--- a/docs/api/stable-v2.21.yaml
+++ b/docs/api/stable-v2.21.yaml
@@ -897,7 +897,7 @@ paths:
     put:
       tags:
         - Service API
-      summary: create and activate service
+      summary: create, associate number and activate service
       operationId: addServiceAndActivate
       consumes:
         - application/json
@@ -2196,6 +2196,10 @@ definitions:
         type: string
         enum:
           - CLOUDCALLING
+      number:
+        type: string
+      activityNumber:
+        type: string
       serviceActivity:
         type: string
         enum:

--- a/services-management-client/src/main/java/mc/monacotelecom/services/client/connector/ServicesManagementConnector.java
+++ b/services-management-client/src/main/java/mc/monacotelecom/services/client/connector/ServicesManagementConnector.java
@@ -137,6 +137,14 @@ public class ServicesManagementConnector extends AbstractConnector {
         return exchange(uri, method, requestEntity, type);
     }
 
+    public <T extends ServiceDTO> T addServiceAndActivate(AddServiceRequestDTO addServiceRequestDTO, Class<T> type) {
+        URI uri = this.getUri(PRIVATE_AUTH, "/services/createandactivate");
+        final var method = HttpMethod.PUT;
+        log.info("Add and activate service with DTO {} by {} on URL={}", addServiceRequestDTO, method, uri);
+        HttpEntity<AddServiceRequestDTO> requestEntity = new HttpEntity<>(addServiceRequestDTO, authHeaders());
+        return exchange(uri, method, requestEntity, type);
+    }
+
     public ChangeTagsResponse changeTags(Long serviceId, ChangeTagsDTO changeTagsDTO) {
         URI uri = this.getUri(PRIVATE_AUTH, "/services/", serviceId + "", "/changetags");
         final var method = HttpMethod.PATCH;

--- a/services-management-dto/src/main/java/mc/monacotelecom/services/dto/request/AddServiceRequestDTO.java
+++ b/services-management-dto/src/main/java/mc/monacotelecom/services/dto/request/AddServiceRequestDTO.java
@@ -25,6 +25,10 @@ public class AddServiceRequestDTO {
 
     private String componentType;
 
+    private String number;
+
+    private String activityNumber;
+
 
 
 }

--- a/services-management-process/src/main/java/mc/monacotelecom/services/process/ServiceProcess.java
+++ b/services-management-process/src/main/java/mc/monacotelecom/services/process/ServiceProcess.java
@@ -163,10 +163,21 @@ public class ServiceProcess {
 
     public synchronized ServiceDTO addServiceAndActivate(AddServiceRequestDTO addServiceRequest) {
         ServiceDTO createdService = addServiceOnSubscription(addServiceRequest);
+
+        if (addServiceRequest.getNumber() != null) {
+            UpdateServiceDTO updateDTO = new UpdateServiceDTO();
+            updateDTO.setAction(ServiceUpdateAction.addNumber);
+            updateDTO.setNumber(addServiceRequest.getNumber());
+            updateDTO.setActivityNumber(addServiceRequest.getActivityNumber());
+            update(createdService.getServiceId(), updateDTO);
+        }
+
         Service service = serviceRepository.findById(createdService.getServiceId())
                 .orElseThrow(() -> new SvcNotFoundException(localizedMessageBuilder, SERVICE_NOT_FOUND_ID, createdService.getServiceId()));
+
         setEventOnService(service, Event.activate);
         serviceRepository.save(service);
+
         if (service.getServiceCategory().equals(ACCESS)) {
             return serviceAccessResourceAssembler.toModel((ServiceAccess) service);
         } else {

--- a/services-management-process/src/main/java/mc/monacotelecom/services/process/ServiceProcess.java
+++ b/services-management-process/src/main/java/mc/monacotelecom/services/process/ServiceProcess.java
@@ -161,6 +161,19 @@ public class ServiceProcess {
         }
     }
 
+    public synchronized ServiceDTO addServiceAndActivate(AddServiceRequestDTO addServiceRequest) {
+        ServiceDTO createdService = addServiceOnSubscription(addServiceRequest);
+        Service service = serviceRepository.findById(createdService.getServiceId())
+                .orElseThrow(() -> new SvcNotFoundException(localizedMessageBuilder, SERVICE_NOT_FOUND_ID, createdService.getServiceId()));
+        setEventOnService(service, Event.activate);
+        serviceRepository.save(service);
+        if (service.getServiceCategory().equals(ACCESS)) {
+            return serviceAccessResourceAssembler.toModel((ServiceAccess) service);
+        } else {
+            return serviceComponentResourceAssembler.toModel((ServiceComponent) service);
+        }
+    }
+
     private void checkBeforeSave(Service service) {
 
         if (service instanceof ServiceAccess) {

--- a/services-management-service/src/main/java/mc/monacotelecom/services/service/ServiceService.java
+++ b/services-management-service/src/main/java/mc/monacotelecom/services/service/ServiceService.java
@@ -66,6 +66,11 @@ public class ServiceService {
         return serviceProcess.addServiceOnSubscription(addServiceRequest);
     }
 
+    @Transactional
+    public ServiceDTO addServiceAndActivate(AddServiceRequestDTO addServiceRequest) {
+        return serviceProcess.addServiceAndActivate(addServiceRequest);
+    }
+
     @Transactional(readOnly = true)
     public ServiceDTO getById(Long serviceId) {
         return serviceProcess.getById(serviceId);

--- a/services-management-webservice/src/main/java/mc/monacotelecom/services/controller/ServiceController.java
+++ b/services-management-webservice/src/main/java/mc/monacotelecom/services/controller/ServiceController.java
@@ -27,6 +27,7 @@ import org.springframework.data.history.Revision;
 import org.springframework.data.web.PagedResourcesAssembler;
 import org.springframework.hateoas.PagedModel;
 import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
@@ -87,6 +88,7 @@ public class ServiceController {
     @ApiResponse(responseCode = "201", description = "Service created and activated")
     @ApiResponse(responseCode = "500", description = "Internal error")
     @PutMapping("/createandactivate")
+    @ResponseStatus(HttpStatus.CREATED)
     public ServiceDTO addServiceAndActivate(@Valid @RequestBody AddServiceRequestDTO addServiceRequest) {
         return serviceService.addServiceAndActivate(addServiceRequest);
     }

--- a/services-management-webservice/src/main/java/mc/monacotelecom/services/controller/ServiceController.java
+++ b/services-management-webservice/src/main/java/mc/monacotelecom/services/controller/ServiceController.java
@@ -83,6 +83,14 @@ public class ServiceController {
         return serviceService.addServiceOnSubscription(addServiceRequest);
     }
 
+    @Operation(summary = "Create and activate a new service")
+    @ApiResponse(responseCode = "201", description = "Service created and activated")
+    @ApiResponse(responseCode = "500", description = "Internal error")
+    @PutMapping("/createandactivate")
+    public ServiceDTO addServiceAndActivate(@Valid @RequestBody AddServiceRequestDTO addServiceRequest) {
+        return serviceService.addServiceAndActivate(addServiceRequest);
+    }
+
     @Operation(summary = "Update an existing service")
     @ApiResponse(responseCode = "200", description = "Service updated")
     @ApiResponse(responseCode = "500", description = "Internal error")

--- a/services-management-webservice/src/test/java/mc/monacotelecom/services/integration/ServiceIntegrationTests.java
+++ b/services-management-webservice/src/test/java/mc/monacotelecom/services/integration/ServiceIntegrationTests.java
@@ -1969,6 +1969,23 @@ class ServiceIntegrationTests extends BaseIntegrationTest {
         }
     }
 
+    @DisplayName("Create and activate service with number")
+    @Nested
+    class CreateAndActivateService {
+
+        @Test
+        void createAndActivate_success() throws Exception {
+            mockMvc.perform(put(ROUTE_SERVICE + "/createandactivate")
+                            .contentType(MediaType.APPLICATION_JSON_VALUE)
+                            .content("{\"subscriptionId\": 1000, \"serviceCategory\": \"ACCESS\", \"serviceActivity\": \"INTERNET\", \"accessType\": \"FTTH\", \"number\": \"12345\", \"activityNumber\": \"INTERNET\"}"))
+                    .andDo(print())
+                    .andExpect(status().isCreated())
+                    .andExpect(jsonPath("$.serviceId").exists())
+                    .andExpect(jsonPath("$.status").value("ACTIVATED"))
+                    .andExpect(jsonPath("$.number").value("12345"));
+        }
+    }
+
     @DisplayName("Update service")
     @Nested
     class UpdateService {


### PR DESCRIPTION
## Summary
- add `addServiceAndActivate` handler in ServiceProcess
- expose creation+activation method in service layer
- create REST endpoint `/createandactivate`
- support new endpoint in client connector
- document new route in API specs

## Testing
- `mvn -q -DskipITs test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841ec20569c8323942fe8442461b238